### PR TITLE
Update duckduckgo dependency - min should be 2.9.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ requests
 tiktoken==0.3.3
 gTTS==2.3.1
 docker
-duckduckgo-search
+duckduckgo-search>=2.9.5
 google-api-python-client #(https://developers.google.com/custom-search/v1/overview)
 pinecone-client==2.2.1
 redis


### PR DESCRIPTION
https://github.com/deedy5/duckduckgo_search/blob/main/README.md

According to readme in duckduckgo_search repo:
Attention. Versions before v2.9.4 no longer work as of May 12, 2023!

Adding this to requirements.txt

With 2.9.4 or earlier you get empty list of results. By updating you get it working again. This is only when autogpt falls back to duckduckgo when trying to do a google search.